### PR TITLE
Don't include extracted test results in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+tests/results/


### PR DESCRIPTION
Hey!

This PR has a quick fix to remove un-neutered malware from built Docker images for the batch deobfuscator. Specifically, the files in tests/results/ are not .CaRT'd and can trip up container scanning.

Let me know if .CaRT'ing the results would be a preferred solution (though not sure these are useful being included in built Docker images regardless).
